### PR TITLE
Update Ajou University Code, Adjust Font Size on Safari, Adjust Width

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,11 @@
         return color = '#' + parts.join('');
     }
 
+    function checkSafari() {
+        if(navigator.userAgent.search("Safari") >= 0) return true;
+        else return false;
+    }
+
     var univNames = ["Adelphi", "CMU", "Harvard", "Stanford",
           "UC Berkeley", "University of Rochester", "UT Rio Grande Valley",
           "University of Washington", "University of Waterloo",
@@ -60,6 +65,10 @@
 
         var univListTemplate = sortedByColor.map(function(univ, i) {
             var box = $('<div/>').addClass('colorBox').css({'background': univ.color}).text(univ.name);
+
+            // If the browser is Safari, add class ".safari"
+            if(checkSafari()) box.addClass('safari');
+
             return box.get(0);
         });
 
@@ -85,11 +94,19 @@
         });
 
         $('.colorBox').hover(function(){
-          $(this).css("opacity", "0.8");
-          $(this).css("font-size", "6.5px");
+            $(this).css("opacity", "0.8");
+            if(checkSafari()) {
+                $(this).css("font-size", "10px");
+            } else {
+                $(this).css("font-size", "6.5px");
+            }
         }, function() {
-          $(this).css("opacity", "1.0");
-          $(this).css("font-size", "5px");
+            $(this).css("opacity", "1.0");
+            if(checkSafari()) {
+                $(this).css("font-size", "9px");
+            } else {
+                $(this).css("font-size", "5px");
+            }
         });
     });
   </script>

--- a/style.css
+++ b/style.css
@@ -43,6 +43,10 @@ ul {
     overflow: hidden;
 }
 
+.colorBox.safari {
+    font-size: 9px;
+}
+
 .ui-autocomplete{
     background:white;
     z-index: 3;
@@ -58,14 +62,22 @@ ul {
 @media screen and (min-width: 768px) {
     /* Tablet */
     .container {
-        width: 75%;
+        width: 80%;
         margin: auto;
     }
 }
 @media screen and (min-width: 992px) {
-    /* Standard */
+    /* Standard Display */
     .container {
-        width: 50%;
+        width: 70%;
+        margin: auto;
+    }
+}
+
+@media screen and (min-width: 1200px) {
+    /* Wide Display */
+    .container {
+        width: 60%;
         margin: auto;
     }
 }

--- a/univColor.js
+++ b/univColor.js
@@ -108,7 +108,7 @@ function getColorByUnivName(univ) {
   if (univ == "SSU" || univ.includes("숭실대")) return "#4badcd";
   if (univ == "SWC" || univ.includes("숭의여대")) return "#062d8f";
 
-  if (univ == "AJU" || univ.includes("아주대")) return "#0072ce";
+  if (univ == "AJOU" || univ.includes("아주대")) return "#0072ce";
   if (univ == "YSU" || univ.includes("연세대")) return "#16407d";
   if (univ == "YU" || univ.includes("영남대")) return "#003e7d";
   if (univ == "INU" || univ.includes("인천대")) return "#0C3689";


### PR DESCRIPTION
1. 아주대 코드가 "AJU"로 되어 있는데, 굳이 3글자로 써야 할 이유가 없는듯 해서 학교 영문 명칭인 "AJOU"로 변경했습니다.

2. 사파리에서 (크롬에서와 달리) 폰트가 매우 작게 보이는 문제를 해결했습니다.
브라우저를 확인해 사파리인 경우 .colorBox에 .safari를 추가하고, :hover 이벤트시 변경되는 스타일도 변경했습니다.
사파리에서도 최대한 크롬과 같이 보이도록 조정했습니다.

3. .container 너비 조정
.container가 너무 좁아 학교를 추가함에 따라 페이지의 길이가 과도하게 길어질 것 같아 조금씩(?) 넓혔습니다.
가로 1200px 이상인 경우에 해당하는 wide display를 새로 추가했습니다.
* tablet(over 768px) : 80%
* standard display(over 992px) : 70%
* wide display(over 1200px) : 60%
